### PR TITLE
Fix link to GitHub source in routes.js

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -14,7 +14,7 @@ export const routes = [
 export const socialLinks = {
   github: {
     name: 'GitHub',
-    path: 'https://github.com/blanchardjeremy/jamvote',
+    path: 'https://github.com/blanchardjeremy/jam-vote',
     icon: 'github'
   }
 } 


### PR DESCRIPTION
I tried the GitHub link and it had a little typo (missing the hyphen).  Alternatively you could rename the repo to match the link (remove the hyphen).