### PR TITLE
Change menu item label for "Browse Songs" to "Add Songs"

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -5,7 +5,7 @@ export const routes = [
     icon: 'music'
   },
   {
-    name: 'Browse Songs',
+    name: 'Add Songs',
     path: '/songs',
     icon: 'library'
   }


### PR DESCRIPTION
I hunted all over the UI on the jam page and couldn't find any way to add a song, until I took a leap of faith and discovered it on the "Browse Songs" page.  How about changing the label to "Add Songs"? It could mean "add new songs to the library" or "add songs from the library to a jam", which are both available through that menu item.